### PR TITLE
correct property name `primitive`=>`mode`

### DIFF
--- a/lib/gltf.js
+++ b/lib/gltf.js
@@ -314,7 +314,7 @@ function createGltf(data, modelName, inputPath, outputPath, binary, embed, techn
                 attributes : gltfAttributes,
                 indices : getAccessorIndexId(i),
                 material : getMaterialId(primitives[i].material),
-                primitive : WebGLConstants.TRIANGLES
+                mode : WebGLConstants.TRIANGLES
             });
         }
 


### PR DESCRIPTION
As the [spec](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md#meshprimitive) says, this property is **mode**, not **primitive**.  