### PR TITLE
Update version for line-ending fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 0.1.6 2016-09-07
+
+* Changed obj2gltf.js line endings from CRLF to LF in npm package.
+
 ### 0.1.5 2016-08-26
 
 * Fixed incorrect parameter to the gltf-pipeline.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj2gltf",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Convert OBJ model format to glTF",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
For #25 

This PR just marks the next npm publish which will change the line-endings of any bin scripts to LF.