### PR TITLE
Update gltf-pipeline and general project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,16 @@
 node_modules
 npm-debug.log
 
+# TypeScript definitions
+typings
+
 # WebStorm user-specific
 .idea/workspace.xml
 .idea/tasks.xml
 
-# TypeScript definitions
-typings
-
 # Generate data
-test
 coverage
+doc
+output
+test
 *.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,10 @@
 /.idea
+/coverage
 /doc
+/output
 /specs
 /test
 /typings
-/coverage
 .jshintrc
 .npmignore
 .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - 4
+  - "4"
+  - "6"
 script:
   - npm run jsHint -- --failTaskOnError
   - npm run test -- --failTaskOnError --suppressPassed
+after_success:
+## We only need to run coveralls for one node version (doesn't matter which one).
+## We also ignore publishing failures, since restarting an existing travis build would otherwise break.
+  - if node --version | grep -q ^v6 ; npm run coveralls ; fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 0.1.7 2017-01-03
+
+* Update gltf-pipeline to 0.1.0-alpha9
+* Added command to generate documentation (npm run jsdoc)
+
 ### 0.1.6 2016-09-07
 
 * Changed obj2gltf.js line endings from CRLF to LF in npm package.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -35,6 +35,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+### bluebird
+
+https://www.npmjs.com/package/bluebird
+
+> The MIT License (MIT)
+>
+> Copyright (c) 2013-2015 Petka Antonov
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 ### byline
 
 https://www.npmjs.com/package/byline

--- a/README.md
+++ b/README.md
@@ -92,5 +92,5 @@ Pull requests are appreciated.  Please use the same [Contributor License Agreeme
 
 Developed by the Cesium team.
 <p align="center">
-<a href="http://cesiumjs.org/"><img src="doc/cesium.png" /></a>
+<a href="http://cesiumjs.org/"><img src="doc/cesium.png" onerror="this.src='cesium.png'"/></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -45,6 +45,45 @@ Using obj2gltf as a command-line tool:
 |`--ao`|Apply ambient occlusion to the converted model.|No, default `false`|
 |`-h`|Display help|No|
 
+## Build Instructions
+
+Run the tests:
+```
+npm run test
+```
+To run JSHint on the entire codebase, run:
+```
+npm run jsHint
+```
+To run JSHint automatically when a file is saved, run the following and leave it open in a console window:
+```
+npm run jsHint-watch
+```
+
+### Running Test Coverage
+
+Coverage uses [istanbul](https://github.com/gotwarlost/istanbul).  Run:
+```
+npm run coverage
+```
+For complete coverage details, open `coverage/lcov-report/index.html`.
+
+The tests and coverage covers the Node.js module; it does not cover the command-line interface, which is tiny.
+
+## Generating Documentation
+
+To generate the documentation:
+```
+npm run jsdoc
+```
+
+The documentation will be placed in the `doc` folder.
+
+### Debugging
+
+* To debug the tests in Webstorm, open the Gulp tab, right click the `test` task, and click `Debug 'test'`.
+* To run a single test, change the test function from `it` to `fit`.
+
 ## Contributions
 
 Pull requests are appreciated.  Please use the same [Contributor License Agreement (CLA)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md) used for [Cesium](http://cesiumjs.org/).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var environmentSeparator = process.platform === 'win32' ? ';' : ':';
 var nodeBinaries = path.join(__dirname, 'node_modules', '.bin');
 process.env.PATH += environmentSeparator + nodeBinaries;
 
-var jsHintFiles = ['**/*.js', '!node_modules/**', '!coverage/**'];
+var jsHintFiles = ['**/*.js', '!node_modules/**', '!coverage/**', '!doc/**'];
 var specFiles = ['**/*.js', '!node_modules/**', '!coverage/**'];
 
 gulp.task('jsHint', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var fsExtra = require('fs-extra');
 var gulp = require('gulp');
 var gulpJshint = require('gulp-jshint');
 var Jasmine = require('jasmine');
-var JasmineSpecReporter = require('jasmine-spec-reporter');
+var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 var open = require('open');
 var path = require('path');
 var yargs = require('yargs');
@@ -42,7 +42,7 @@ gulp.task('jsHint-watch', function () {
 gulp.task('test', function (done) {
     var jasmine = new Jasmine();
     jasmine.loadConfigFile('specs/jasmine.json');
-    jasmine.addReporter(new JasmineSpecReporter({
+    jasmine.addReporter(new SpecReporter({
         displaySuccessfulSpec: !defined(argv.suppressPassed) || !argv.suppressPassed
     }));
     jasmine.execute();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj2gltf",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Convert OBJ model format to glTF",
   "license": "Apache-2.0",
   "contributors": [
@@ -26,33 +26,37 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "async": "2.1.2",
-    "bluebird": "3.4.6",
-    "byline": "5.0.0",
-    "cesium": "1.26.0",
-    "fs-extra": "0.30.0",
-    "gltf-pipeline": "0.1.0-alpha8",
-    "yargs": "6.3.0"
+    "async": "^2.1.4",
+    "bluebird": "^3.4.7",
+    "byline": "^5.0.0",
+    "cesium": "^1.29.0",
+    "fs-extra": "^1.0.0",
+    "gltf-pipeline": "^0.1.0-alpha9",
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
-    "gulp": "3.9.1",
-    "gulp-jshint": "2.0.2",
-    "istanbul": "0.4.5",
-    "jasmine": "2.5.2",
-    "jasmine-spec-reporter": "2.7.0",
-    "jshint": "2.9.4",
-    "jshint-stylish": "2.2.1",
-    "open": "0.0.5",
-    "requirejs": "2.3.2",
-    "typings": "1.4.0"
+    "coveralls": "^2.11.15",
+    "gulp": "^3.9.1",
+    "gulp-jshint": "^2.0.4",
+    "istanbul": "^0.4.5",
+    "jasmine": "^2.5.2",
+    "jasmine-spec-reporter": "^3.0.0",
+    "jsdoc": "^3.4.3",
+    "jshint": "^2.9.4",
+    "jshint-stylish": "^2.2.1",
+    "open": "^0.0.5",
+    "requirejs": "^2.3.2",
+    "typings": "^2.1.0"
   },
   "scripts": {
     "prepublish": "typings install",
+    "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "jsHint": "gulp jsHint",
     "jsHint-watch": "gulp jsHint-watch",
     "test": "gulp test",
     "test-watch": "gulp test-watch",
-    "coverage": "gulp coverage"
+    "coverage": "gulp coverage",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "bin": {
     "obj2gltf": "./bin/obj2gltf.js"


### PR DESCRIPTION
* Bumped to 0.1.7
* Updated travis (@pjcozzi forgot to wait for this one - but it fixes https://github.com/AnalyticalGraphicsInc/obj2gltf/issues/40)
* Using ^ in package.json
* Added jsdoc
* Upgrade gltf-pipeline

The travis build is failing at `JasmineSpecReporter is not a constructor` but succeeds for master. I may need to downgrade `jasmine-spec-reporter`.

I'll publish once this PR is in.
