### PR TITLE
Return Promise.reject instead of throwing error

### DIFF
--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -15,6 +15,7 @@ var fsExtraOutputJson = Promise.promisify(fsExtra.outputJson);
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
+var RuntimeError = Cesium.RuntimeError;
 
 module.exports = obj2gltf;
 
@@ -85,7 +86,7 @@ function obj2gltf(objPath, gltfPath, options) {
     }
 
     if (binary && bypassPipeline) {
-        throw new DeveloperError('--bypassPipeline does not convert to binary glTF');
+        return Promise.reject(new RuntimeError('--bypassPipeline does not convert to binary glTF'));
     }
 
     gltfPath = path.join(path.dirname(gltfPath), modelName + extension);


### PR DESCRIPTION
For #71 

This is for proper error reporting when `--bypassPipeline` and `-b` are both set, which isn't allowed right now.

I don't think this counts as incorrect usage of the library, so I'm rejecting the promise instead of throwing an error. Otherwise the error is not caught in `bin/obj2gltf.js`.

If this should still be a `DeveloperError`, I can wrap the `obj2gltf` call in `bin/obj2gltf.js` in a try-catch.