### PR TITLE
Treat alpha as 1.0 - Tr

### DIFF
--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -66,7 +66,7 @@ function loadMtl(mtlPath) {
             material.alpha = parseFloat(value);
         } else if (/^Tr /i.test(line)) {
             value = line.substring(3).trim();
-            material.alpha = parseFloat(value);
+            material.alpha = 1.0 - parseFloat(value);
         } else if (/^map_Ka /i.test(line)) {
             material.ambientTexture = path.resolve(mtlDirectory, line.substring(7).trim());
         } else if (/^map_Ke /i.test(line)) {

--- a/specs/data/box-complex-material/box-complex-material.mtl
+++ b/specs/data/box-complex-material/box-complex-material.mtl
@@ -9,7 +9,7 @@ Ks 0.500000 0.500000 0.500000
 Ke 0.100000 0.100000 0.100000
 Ni 1.000000
 d 0.900000
-Tr 0.900000
+Tr 0.100000
 map_Ka ambient.gif
 map_Ke emission.jpg
 map_Kd diffuse.png


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/obj2gltf/issues/76

Fixes parsing the `Tr` property. By convention a value of 0 means opaque and 1 means translucent, I had it backwards.