### PR TITLE
Update npm dependencies

### DIFF
--- a/lib/loadImage.js
+++ b/lib/loadImage.js
@@ -5,8 +5,6 @@ var path = require('path');
 var PNG = require('pngjs').PNG;
 var Promise = require('bluebird');
 
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-
 var defined = Cesium.defined;
 var WebGLConstants = Cesium.WebGLConstants;
 
@@ -23,7 +21,7 @@ module.exports = loadImage;
  * @private
  */
 function loadImage(imagePath, options) {
-    return fsExtraReadFile(imagePath)
+    return fsExtra.readFile(imagePath)
         .then(function(data) {
             var extension = path.extname(imagePath).toLowerCase();
 

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -10,8 +10,6 @@ var createGltf = require('./createGltf');
 var loadObj = require('./loadObj');
 var writeUris = require('./writeUris');
 
-var fsExtraOutputJson = Promise.promisify(fsExtra.outputJson);
-
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
@@ -121,7 +119,7 @@ function obj2gltf(objPath, gltfPath, options) {
         })
         .then(function(gltf) {
             if (bypassPipeline) {
-                return obj2gltf._outputJson(gltfPath, gltf);
+                return fsExtra.outputJson(gltfPath, gltf);
             } else {
                 return GltfPipeline.processJSONToDisk(gltf, gltfPath, pipelineOptions);
             }
@@ -236,13 +234,6 @@ obj2gltf.defaults = {
         console.log(message);
     }
 };
-
-/**
- * Exposed for testing
- *
- * @private
- */
-obj2gltf._outputJson = fsExtraOutputJson;
 
 /**
  * Exposed for testing

--- a/lib/writeUris.js
+++ b/lib/writeUris.js
@@ -5,8 +5,6 @@ var mime = require('mime');
 var path = require('path');
 var Promise = require('bluebird');
 
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
-
 var RuntimeError = Cesium.RuntimeError;
 
 module.exports = writeUris;
@@ -88,7 +86,7 @@ function writeSeparateBuffer(gltf, resourcesDirectory, name) {
     var bufferUri = name + '.bin';
     buffer.uri = bufferUri;
     var bufferPath = path.join(resourcesDirectory, bufferUri);
-    return writeUris._outputFile(bufferPath, source);
+    return fsExtra.outputFile(bufferPath, source);
 }
 
 function writeSeparateTextures(gltf, resourcesDirectory) {
@@ -99,7 +97,7 @@ function writeSeparateTextures(gltf, resourcesDirectory) {
         var imageUri = image.name + extras.extension;
         image.uri = imageUri;
         var imagePath = path.join(resourcesDirectory, imageUri);
-        return writeUris._outputFile(imagePath, extras.source);
+        return fsExtra.outputFile(imagePath, extras.source);
     }, {concurrency : 10});
 }
 
@@ -119,10 +117,3 @@ function writeEmbeddedTextures(gltf) {
         }
     }
 }
-
-/**
- * Exposed for testing.
- *
- * @private
- */
-writeUris._outputFile = fsExtraOutputFile;

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "bluebird": "^3.4.7",
     "cesium": "^1.31.0",
     "event-stream": "^3.3.4",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "^3.0.1",
     "gltf-pipeline": "^0.1.0-alpha11",
     "mime": "^1.3.4",
     "pngjs": "^3.0.1",
     "uuid": "^3.0.1",
-    "yargs": "^7.0.1"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.12.0",
@@ -42,7 +42,7 @@
     "gulp-jshint": "^2.0.4",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.3",
-    "jasmine-spec-reporter": "^3.2.0",
+    "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",

--- a/specs/lib/createGltfSpec.js
+++ b/specs/lib/createGltfSpec.js
@@ -13,8 +13,6 @@ var writeUris = require('../../lib/writeUris');
 var clone = Cesium.clone;
 var WebGLConstants = Cesium.WebGLConstants;
 
-var fsExtraReadJson = Promise.promisify(fsExtra.readJson);
-
 var boxObjUrl = 'specs/data/box/box.obj';
 var groupObjUrl = 'specs/data/box-objects-groups-materials/box-objects-groups-materials.obj';
 var boxGltfUrl = 'specs/data/box/box.gltf';
@@ -49,11 +47,11 @@ describe('createGltf', function() {
                 .then(function(data) {
                     groupObjData = data;
                 }),
-            fsExtraReadJson(boxGltfUrl)
+            fsExtra.readJson(boxGltfUrl)
                 .then(function(gltf) {
                     boxGltf = gltf;
                 }),
-            fsExtraReadJson(groupGltfUrl)
+            fsExtra.readJson(groupGltfUrl)
                 .then(function(gltf) {
                     groupGltf = gltf;
                 }),

--- a/specs/lib/obj2gltfSpec.js
+++ b/specs/lib/obj2gltfSpec.js
@@ -19,8 +19,8 @@ describe('obj2gltf', function() {
         expect(obj2gltf._getTempDirectory()).toContain(os.tmpdir());
         tempDirectory = path.join(os.tmpdir(), 'testPath');
         spyOn(obj2gltf, '_getTempDirectory').and.returnValue(tempDirectory);
-        spyOn(obj2gltf, '_outputJson');
-        spyOn(writeUris, '_outputFile');
+        spyOn(fsExtra, 'outputJson');
+        spyOn(fsExtra, 'outputFile');
         spyOn(fsExtra, 'remove');
     });
 
@@ -100,7 +100,7 @@ describe('obj2gltf', function() {
                     textureCompressionOptions : textureCompressionOptions,
                     preserve : false
                 });
-                expect(writeUris._outputFile.calls.count()).toBe(2); // Saves out .png and .bin
+                expect(fsExtra.outputFile.calls.count()).toBe(2); // Saves out .png and .bin
             }), done).toResolve();
     });
 
@@ -119,7 +119,7 @@ describe('obj2gltf', function() {
         };
         expect(obj2gltf(objPath, gltfPath, options)
             .then(function() {
-                expect(obj2gltf._outputJson).toHaveBeenCalled();
+                expect(fsExtra.outputJson).toHaveBeenCalled();
                 expect(GltfPipeline.processJSONToDisk).not.toHaveBeenCalled();
             }), done).toResolve();
     });


### PR DESCRIPTION
A few npm dependencies were major versions behind, so this updates `yargs`, `fs-extra`, and `jasmin-spec-reporter` to their latest versions.

The major change here is `fs-extra`, which now has promise implementations of all functions by default, this means there's no reason to manually `Promisify` a function any more, the result is less code overall.

There is one important edge case, `fs-extra` uses built-in native Node promises, which do not have a `finally` function. If you start a promise change with an `fs-extra` function, you need to wrap it in `Promise.resolve` in order to make use of finally at the end (assuming you are using finally at all, if not you don't need to worry about it. The upside is that your code will always error if you forget to do this.