### PR TITLE
Replace Istanbul with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ doc
 output
 test
 *.tgz
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm run eslint-watch
 
 ## Running Test Coverage
 
-Coverage uses [istanbul](https://github.com/gotwarlost/istanbul).  Run:
+Coverage uses [nyc](https://github.com/istanbuljs/nyc).  Run:
 ```
 npm run coverage
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,9 +70,9 @@ gulp.task('test-watch', function () {
 
 gulp.task('coverage', function () {
     fsExtra.removeSync('coverage/server');
-    child_process.execSync('istanbul' +
-        ' cover' +
-        ' --include-all-sources' +
+    child_process.execSync('nyc' +
+        ' --all' +
+        ' --reporter=lcov' +
         ' --dir coverage' +
         ' -x "specs/**" -x "coverage/**" -x "doc/**" -x "bin/**" -x "index.js" -x "gulpfile.js"' +
         ' node_modules/jasmine/bin/jasmine.js' +

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "eslint-config-cesium": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^4.0.0",
-    "istanbul": "^0.4.5",
     "jasmine": "^2.5.3",
     "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
+    "nyc": "^11.0.2",
     "open": "^0.0.5",
     "requirejs": "^2.3.3"
   },


### PR DESCRIPTION
Simple switch from `Istanbul` to [`nyc`](https://github.com/istanbuljs/nyc) for code coverage.