### PR TITLE
Switch from gulp-eslint to the ESLint CLI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/**
+coverage/**
+doc/**

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generate data
+.eslintcache
 coverage
 doc
 output

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "4"
   - "6"
 script:
-  - npm run eslint -- --failTaskOnError
+  - npm run eslint
   - npm run test -- --failTaskOnError --suppressPassed
 
 after_success:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ var Cesium = require('cesium');
 var child_process = require('child_process');
 var fsExtra = require('fs-extra');
 var gulp = require('gulp');
-var eslint = require('gulp-eslint');
 var Jasmine = require('jasmine');
 var JasmineSpecReporter = require('jasmine-spec-reporter').SpecReporter;
 var open = require('open');
@@ -20,27 +19,7 @@ var environmentSeparator = process.platform === 'win32' ? ';' : ':';
 var nodeBinaries = path.join(__dirname, 'node_modules', '.bin');
 process.env.PATH += environmentSeparator + nodeBinaries;
 
-var esLintFiles = ['**/*.js', '!node_modules/**', '!coverage/**', '!doc/**'];
 var specFiles = ['**/*.js', '!node_modules/**', '!coverage/**', '!doc/**', '!bin/**'];
-
-gulp.task('eslint', function () {
-    var stream = gulp.src(esLintFiles)
-        .pipe(eslint())
-        .pipe(eslint.format());
-    if (argv.failTaskOnError) {
-        stream = stream.pipe(eslint.failAfterError());
-    }
-
-    return stream;
-});
-
-gulp.task('eslint-watch', function() {
-    gulp.watch(esLintFiles).on('change', function(event) {
-        gulp.src(event.path)
-            .pipe(eslint())
-            .pipe(eslint.format());
-    });
-});
 
 gulp.task('test', function (done) {
     var jasmine = new Jasmine();

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -121,9 +121,8 @@ function obj2gltf(objPath, gltfPath, options) {
         .then(function(gltf) {
             if (bypassPipeline) {
                 return fsExtra.outputJson(gltfPath, gltf);
-            } else {
-                return GltfPipeline.processJSONToDisk(gltf, gltfPath, pipelineOptions);
             }
+            return GltfPipeline.processJSONToDisk(gltf, gltfPath, pipelineOptions);
         })
         .finally(function() {
             return cleanup(resourcesDirectory, options);

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   },
   "devDependencies": {
     "coveralls": "^2.12.0",
-    "eslint-config-cesium": "^1.0.0",
+    "eslint": "^4.1.1",
+    "eslint-config-cesium": "^2.0.0",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^4.0.0",
     "jasmine": "^2.5.3",
     "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
@@ -50,8 +50,7 @@
   },
   "scripts": {
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
-    "eslint": "gulp eslint",
-    "eslint-watch": "gulp eslint-watch",
+    "eslint": "eslint \"./**/*.js\" --cache --quiet",
     "test": "gulp test",
     "test-watch": "gulp test-watch",
     "coverage": "gulp coverage",


### PR DESCRIPTION
Move from `gulp-eslint`to a simple CLI invocation of ESLint. This allows for caching and drastically increases the speed of running `npm run eslint`. In addition, bump `eslint-cesium-config` to 2.0.0.