### PR TITLE
Remove dependency on event-stream

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -246,35 +246,6 @@ http://cesiumjs.org/
 
 See https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-### event-stream
-
-https://www.npmjs.com/package/event-stream
-
-> The MIT License (MIT)
->
-> Copyright (c) 2011 Dominic Tarr
->
-> Permission is hereby granted, free of charge,
-> to any person obtaining a copy of this software and
-> associated documentation files (the "Software"), to
-> deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify,
-> merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom
-> the Software is furnished to do so,
-> subject to the following conditions:
->
-> The above copyright notice and this permission notice
-> shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-> OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-> ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 ### fs-extra
 
 https://www.npmjs.com/package/fs-extra

--- a/lib/readLines.js
+++ b/lib/readLines.js
@@ -1,7 +1,7 @@
 'use strict';
-var eventStream = require('event-stream');
 var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
+var readline = require('readline');
 
 module.exports = readLines;
 
@@ -15,13 +15,14 @@ module.exports = readLines;
  * @private
  */
 function readLines(path, callback) {
-    return new Promise(function(resolve, reject) {
-        fsExtra.createReadStream(path)
-            .on('error', reject)
-            .on('end', resolve)
-            .pipe(eventStream.split())
-            .pipe(eventStream.mapSync(function (line) {
-                callback(line);
-            }));
+    return new Promise(function (resolve, reject) {
+        var stream = fsExtra.createReadStream(path);
+        stream.on('error', reject);
+        stream.on('end', resolve);
+
+        var lineReader = readline.createInterface({
+            input: stream
+        });
+        lineReader.on('line', callback);
     });
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "cesium": "^1.31.0",
-    "event-stream": "^3.3.4",
     "fs-extra": "^3.0.1",
     "gltf-pipeline": "^0.1.0-alpha11",
     "mime": "^1.3.4",


### PR DESCRIPTION
Node has built in functions for reading lines from a file, so there's no need to depend on `event-stream` just for it.