### PR TITLE
Constant lighting added back to materialsCommon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### 2.1.0 ???
 
+* Added back support for the `CONSTANT` technique when a model uses the `KHR_materials_common` extension and has no normals. [#108](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/108)
 * Improved handling of materials with alpha. If the alpha value is 0.0 it is now treated as 1.0. [#107](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/107)
 
 ### 2.0.0 2017-08-11

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -25,6 +25,7 @@ module.exports = loadMtl;
  *
  * @param {String} mtlPath Path to the .mtl file.
  * @param {Object} options The options object passed along from lib/obj2gltf.js
+ * @param {Boolean} options.hasNormals Whether the model has normals.
  * @returns {Promise} A promise resolving to an array of glTF materials with Texture objects stored in the texture slots.
  *
  * @private
@@ -224,7 +225,7 @@ function convertMaterial(material, options) {
     } else if (options.metallicRoughness) {
         return createMetallicRoughnessMaterial(material, options);
     } else if (options.materialsCommon) {
-        return createMaterialsCommonMaterial(material);
+        return createMaterialsCommonMaterial(material, options);
     }
 
     // No material type specified, convert the material to metallic roughness
@@ -609,7 +610,7 @@ function convertTraditionalToMetallicRoughness(material) {
     material.specularShininess = roughnessFactor;
 }
 
-function createMaterialsCommonMaterial(material) {
+function createMaterialsCommonMaterial(material, options) {
     var ambient = defaultValue(material.ambientTexture, material.ambientColor);
     var diffuse = defaultValue(material.diffuseTexture, material.diffuseColor);
     var emission = defaultValue(material.emissiveTexture, material.emissiveColor);
@@ -637,8 +638,13 @@ function createMaterialsCommonMaterial(material) {
     }
 
     var doubleSided = transparent;
-
     var technique = hasSpecular ? 'PHONG' : 'LAMBERT';
+
+    if (!options.hasNormals) {
+        // Constant technique only factors in ambient and emission sources - set emission to diffuse
+        emission = diffuse;
+        technique = 'CONSTANT';
+    }
 
     return {
         name : material.name,

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -482,6 +482,9 @@ function loadObj(objPath, options) {
     // Parse the obj file
     return readLines(objPath, parseLine)
         .then(function() {
+            // Add hasNormals to options object for loadMtl
+            options.hasNormals = normals.length > 0;
+
             // Unload resources
             positions = undefined;
             normals = undefined;

--- a/specs/lib/loadMtlSpec.js
+++ b/specs/lib/loadMtlSpec.js
@@ -84,6 +84,7 @@ describe('loadMtl', function() {
         options = clone(obj2gltf.defaults);
         options.overridingTextures = {};
         options.logger = function() {};
+        options.hasNormals = true;
     });
 
     it('loads mtl', function(done) {
@@ -458,6 +459,21 @@ describe('loadMtl', function() {
             expect(extension.technique).toBe('PHONG');
             expect(values.specular).toEqual([0.1, 0.1, 0.2, 1]);
             expect(values.shininess).toEqual(0.1);
+        });
+
+        it('sets CONSTANT technique when there are no normals', function() {
+            options.materialsCommon = true;
+            options.hasNormals = false;
+
+            var material = loadMtl._createMaterial({
+                diffuseColor : [1.0, 1.0, 1.0, 1.0]
+            }, options);
+
+            var extension = material.extensions.KHR_materials_common;
+            var values = extension.values;
+
+            expect(extension.technique).toBe('CONSTANT');
+            expect(values.emission).toEqual(values.diffuse);
         });
 
         it('ambient of [1, 1, 1] is treated as [0, 0, 0]', function() {


### PR DESCRIPTION
At some point during the 2.0 refactor I dropped support for the `CONSTANT` lighting mode for `KHR_materials_common`, but it is worth adding back. The model just needs to pass along whether it has normals.

This is for https://github.com/AnalyticalGraphicsInc/cesium/issues/5835.

@shehzan10 can you review?