### PR TITLE
Switched texture loading order so diffuse is always first

### DIFF
--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -34,7 +34,6 @@ function loadMtl(mtlPath, options) {
     var material;
     var values;
     var value;
-    var texturePath;
 
     var mtlDirectory = path.dirname(mtlPath);
     var materials = [];
@@ -58,9 +57,9 @@ function loadMtl(mtlPath, options) {
         checkTransparency : options.checkTransparency
     };
 
-    var ambientTextureOptions = options.packOcclusion ? decodeOptions : undefined;
-    var specularTextureOptions = decodeOptions;
-    var specularShinessTextureOptions = decodeOptions;
+    var ambientTextureOptions = defined(overridingAmbientTexture) ? undefined : (options.packOcclusion ? decodeOptions : undefined);
+    var specularTextureOptions = defined(overridingSpecularTexture) ? undefined : decodeOptions;
+    var specularShinessTextureOptions = defined(overridingSpecularShininessTexture) ? undefined : decodeOptions;
     var emissiveTextureOptions;
     var normalTextureOptions;
 
@@ -68,12 +67,12 @@ function loadMtl(mtlPath, options) {
         material = new Material();
         material.name = name;
         material.specularShininess = options.metallicRoughness ? 1.0 : 0.0;
-        loadMaterialTexture(material, 'specularTexture', overridingSpecularTexture, undefined, mtlDirectory, texturePromiseMap, texturePromises, options);
-        loadMaterialTexture(material, 'specularShininessTexture', overridingSpecularShininessTexture, undefined, mtlDirectory, texturePromiseMap, texturePromises, options);
-        loadMaterialTexture(material, 'ambientTexture', overridingAmbientTexture, undefined, mtlDirectory, texturePromiseMap, texturePromises, options);
-        loadMaterialTexture(material, 'normalTexture', overridingNormalTexture, undefined, mtlDirectory, texturePromiseMap, texturePromises, options);
-        loadMaterialTexture(material, 'diffuseTexture', overridingDiffuseTexture, diffuseTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
-        loadMaterialTexture(material, 'emissiveTexture', overridingEmissiveTexture, undefined, mtlDirectory, texturePromiseMap, texturePromises, options);
+        material.specularTexture = overridingSpecularTexture;
+        material.specularShininessTexture = overridingSpecularShininessTexture;
+        material.diffuseTexture = overridingDiffuseTexture;
+        material.ambientTexture = overridingAmbientTexture;
+        material.normalTexture = overridingNormalTexture;
+        material.emissiveTexture = overridingEmissiveTexture;
         materials.push(material);
     }
 
@@ -140,39 +139,46 @@ function loadMtl(mtlPath, options) {
             material.alpha = correctAlpha(1.0 - parseFloat(value));
         } else if (/^map_Ka /i.test(line)) {
             if (!defined(overridingAmbientTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
-                loadMaterialTexture(material, 'ambientTexture', texturePath, ambientTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.ambientTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
             }
         } else if (/^map_Ke /i.test(line)) {
             if (!defined(overridingEmissiveTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
-                loadMaterialTexture(material, 'emissiveTexture', texturePath, emissiveTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.emissiveTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
             }
         } else if (/^map_Kd /i.test(line)) {
             if (!defined(overridingDiffuseTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
-                loadMaterialTexture(material, 'diffuseTexture', texturePath, diffuseTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.diffuseTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
             }
         } else if (/^map_Ks /i.test(line)) {
             if (!defined(overridingSpecularTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
-                loadMaterialTexture(material, 'specularTexture', texturePath, specularTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.specularTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
             }
         } else if (/^map_Ns /i.test(line)) {
             if (!defined(overridingSpecularShininessTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
-                loadMaterialTexture(material, 'specularShininessTexture', texturePath, specularShinessTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.specularShininessTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(7).trim()));
             }
         } else if (/^map_Bump /i.test(line)) {
             if (!defined(overridingNormalTexture)) {
-                texturePath = path.resolve(mtlDirectory, cleanTextureName(line.substring(9).trim()));
-                loadMaterialTexture(material, 'normalTexture', texturePath, normalTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+                material.normalTexture = path.resolve(mtlDirectory, cleanTextureName(line.substring(9).trim()));
             }
         }
     }
 
+    function loadMaterialTextures(material) {
+        loadMaterialTexture(material, 'diffuseTexture', diffuseTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+        loadMaterialTexture(material, 'ambientTexture', ambientTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+        loadMaterialTexture(material, 'emissiveTexture', emissiveTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+        loadMaterialTexture(material, 'specularTexture', specularTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+        loadMaterialTexture(material, 'specularShininessTexture', specularShinessTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+        loadMaterialTexture(material, 'normalTexture', normalTextureOptions, mtlDirectory, texturePromiseMap, texturePromises, options);
+    }
+
     return readLines(mtlPath, parseLine)
         .then(function() {
+            var length = materials.length;
+            for (var i = 0; i < length; ++i) {
+                loadMaterialTextures(materials[i]);
+            }
             return Promise.all(texturePromises);
         })
         .then(function() {
@@ -210,7 +216,8 @@ loadMtl._createMaterial = function(materialOptions, options) {
     return convertMaterial(combine(materialOptions, new Material()), options);
 };
 
-function loadMaterialTexture(material, name, texturePath, textureOptions, mtlDirectory, texturePromiseMap, texturePromises, options) {
+function loadMaterialTexture(material, name, textureOptions, mtlDirectory, texturePromiseMap, texturePromises, options) {
+    var texturePath = material[name];
     if (!defined(texturePath)) {
         return;
     }


### PR DESCRIPTION
Fixes #112 

The diffuse texture is now guaranteed to load first.

Before if any other texture referred to the same path as the diffuse texture it would load it without checking for transparency.

@PrincessGod could you test this branch?