### PR TITLE
Update npm modules

### DIFF
--- a/lib/writeUris.js
+++ b/lib/writeUris.js
@@ -113,7 +113,7 @@ function writeEmbeddedTextures(gltf) {
         if (images.hasOwnProperty(id)) {
             var image = images[id];
             var extras = image.extras._obj2gltf;
-            image.uri = 'data:' + mime.lookup(extras.extension) + ';base64,' + extras.source.toString('base64');
+            image.uri = 'data:' + mime.getType(extras.extension) + ';base64,' + extras.source.toString('base64');
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,19 +28,19 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cesium": "^1.35.2",
-    "fs-extra": "^3.0.1",
+    "fs-extra": "^5.0.0",
     "gltf-pipeline": "^1.0.0",
-    "mime": "^1.3.6",
+    "mime": "^2.2.0",
     "pngjs": "^3.2.0",
     "uuid": "^3.1.0",
-    "yargs": "^8.0.2"
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.13.1",
+    "coveralls": "^3.0.0",
     "eslint": "^4.2.0",
-    "eslint-config-cesium": "^2.0.1",
+    "eslint-config-cesium": "^4.0.0",
     "gulp": "^3.9.1",
-    "jasmine": "^2.6.0",
+    "jasmine": "^3.1.0",
     "jasmine-spec-reporter": "^4.1.1",
     "jsdoc": "^3.5.1",
     "nyc": "^11.0.3",


### PR DESCRIPTION
Note, this PR is into the 1.0 branch.  Since some people are still using 1.0 for glTF 1.x support, this bumps npm dependencies to their latest versions. Only `mime` required a minor code change on our end.