### PR TITLE
Handle empty -i -o arguments in CLI

### DIFF
--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -128,6 +128,16 @@ if (defined(argv.metallicRoughnessOcclusionTexture) && defined(argv.specularGlos
 var objPath = argv.input;
 var gltfPath = argv.output;
 
+if (objPath === '.') {
+    console.log('Input path is required');
+    return;
+}
+
+if (gltfPath === '.') {
+    console.log('Output path must be a filename');
+    return;
+}
+
 var filename = defaultValue(gltfPath, objPath);
 var name = path.basename(filename, path.extname(filename));
 var outputDirectory = path.dirname(filename);

--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -23,14 +23,24 @@ var argv = yargs
             alias : 'i',
             describe : 'Path to the obj file.',
             type : 'string',
-            normalize : true,
-            demandOption : true
+            demandOption : true,
+            coerce : function (p) {
+                if (p.length === 0) {
+                    throw new Error('Input path must be a file name');
+                }
+                return path.resolve(p);
+            }
         },
         output : {
             alias : 'o',
             describe : 'Path of the converted glTF or glb file.',
             type : 'string',
-            normalize : true
+            coerce : function (p) {
+                if (p.length === 0) {
+                    throw new Error('Output path must be a file name');
+                }
+                return path.resolve(p);
+            }
         },
         binary : {
             alias : 'b',
@@ -127,16 +137,6 @@ if (defined(argv.metallicRoughnessOcclusionTexture) && defined(argv.specularGlos
 
 var objPath = argv.input;
 var gltfPath = argv.output;
-
-if (objPath === '.') {
-    console.log('Input path is required');
-    return;
-}
-
-if (gltfPath === '.') {
-    console.log('Output path must be a filename');
-    return;
-}
 
 var filename = defaultValue(gltfPath, objPath);
 var name = path.basename(filename, path.extname(filename));


### PR DESCRIPTION
Gives more helpful error messages if `-i` or `-o` are passed to the command line but are not followed by a filename.

Example: `obj2gtlf -i file.obj -o` will print `Output path must be a filename`
Example: `obj2gtlf -i` will print `Input path is required`


I'd prefer if this check could be done from the yargs side. Does anyone know if yargs can demand a string option to be greater than zero length?