### PR TITLE
load greyscale images as luminance instead of alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-### 1.4.0
+### 1.3.2 2018-06-07
 * Fixed greyscale images loading as alpha instead of luminance. [#144](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/144)
 
 ### 1.3.1 2018-03-28

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 1.4.0
+* Fixed greyscale images loading as alpha instead of luminance. [#144](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/144)
+
 ### 1.3.1 2018-03-28
 * Maintenance release to update major version Node dependencies.
 

--- a/lib/loadImage.js
+++ b/lib/loadImage.js
@@ -96,7 +96,7 @@ function getChannels(colorType) {
 function getFormat(channels) {
     switch (channels) {
         case 1:
-            return WebGLConstants.ALPHA;
+            return WebGLConstants.LUMINANCE;
         case 2:
             return WebGLConstants.LUMINANCE_ALPHA;
         case 3:

--- a/specs/lib/loadImageSpec.js
+++ b/specs/lib/loadImageSpec.js
@@ -60,7 +60,7 @@ describe('loadImage', function() {
         expect(loadImage(grayscaleImage, defaultOptions)
             .then(function(info) {
                 expect(info.transparent).toBe(false);
-                expect(info.format).toBe(WebGLConstants.ALPHA);
+                expect(info.format).toBe(WebGLConstants.LUMINANCE);
                 expect(info.source).toBeDefined();
                 expect(info.extension).toBe('.png');
             }), done).toResolve();


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/obj2gltf/issues/143