### PR TITLE
Fix objs with interleaved materials

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2.3.1 2018-10-11
+
+* Fixed handling of objs with interleaved materials. [#155](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/155)
+
 ### 2.3.0 2018-09-19
 
 * Fixed handling of objs with mismatching attribute layouts. [#153](https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/153)

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -96,6 +96,11 @@ function loadObj(objPath, options) {
 
     var vertexIndices = [];
 
+    function clearVertexCache() {
+        vertexCache = {};
+        vertexCacheCount = 0;
+    }
+
     function getName(name) {
         return (name === '' ? undefined : name);
     }
@@ -120,8 +125,7 @@ function loadObj(objPath, options) {
         mesh.primitives.push(primitive);
 
         // Clear the vertex cache for each new primitive
-        vertexCache = {};
-        vertexCacheCount = 0;
+        clearVertexCache();
         vertexCount = 0;
     }
 
@@ -135,6 +139,7 @@ function loadObj(objPath, options) {
         for (var i = 0; i < primitivesLength; ++i) {
             if (primitives[i].material === material) {
                 primitive = primitives[i];
+                clearVertexCache();
                 vertexCount = primitive.positions.length / 3;
                 return;
             }
@@ -196,8 +201,7 @@ function loadObj(objPath, options) {
             // may be some duplicate vertices.
             vertexCacheCount++;
             if (vertexCacheCount > vertexCacheLimit) {
-                vertexCacheCount = 0;
-                vertexCache = {};
+                clearVertexCache();
             }
         }
         return index;

--- a/lib/loadObj.js
+++ b/lib/loadObj.js
@@ -135,6 +135,7 @@ function loadObj(objPath, options) {
         for (var i = 0; i < primitivesLength; ++i) {
             if (primitives[i].material === material) {
                 primitive = primitives[i];
+                vertexCount = primitive.positions.length / 3;
                 return;
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj2gltf",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Convert OBJ model format to glTF",
   "license": "Apache-2.0",
   "contributors": [

--- a/specs/lib/loadObjSpec.js
+++ b/specs/lib/loadObjSpec.js
@@ -309,6 +309,14 @@ describe('loadObj', function() {
                 expect(primitives[0].material).toBe('Red');
                 expect(primitives[1].material).toBe('Green');
                 expect(primitives[2].material).toBe('Blue');
+
+                var expectedIndices = [0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7];
+                var length = expectedIndices.length;
+                for (var i = 0; i < 3; ++i) {
+                    for (var j = 0; j < length; ++j) {
+                        expect(primitives[i].indices.get(j)).toBe(expectedIndices[j]);
+                    }
+                }
             }), done).toResolve();
     });
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/153 where the vertex count was not getting reset properly when an obj has interleaved materials.