### PR TITLE
Upgrade to gulp4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,14 @@ process.env.PATH += environmentSeparator + nodeBinaries;
 
 var specFiles = ['**/*.js', '!node_modules/**', '!coverage/**', '!doc/**', '!bin/**'];
 
-gulp.task('test', function (done) {
+module.exports = {
+    test: test,
+    'test-watch': testWatch,
+    coverage: coverage,
+    cloc: cloc
+};
+
+function test(done) {
     var jasmine = new Jasmine();
     jasmine.loadConfigFile('specs/jasmine.json');
     jasmine.addReporter(new JasmineSpecReporter({
@@ -32,9 +39,9 @@ gulp.task('test', function (done) {
     jasmine.onComplete(function (passed) {
         done(argv.failTaskOnError && !passed ? 1 : 0);
     });
-});
+}
 
-gulp.task('test-watch', function () {
+function testWatch() {
     gulp.watch(specFiles).on('change', function () {
         // We can't simply depend on the test task because Jasmine
         // does not like being run multiple times in the same process.
@@ -46,9 +53,9 @@ gulp.task('test-watch', function () {
             console.log('Tests failed to execute.');
         }
     });
-});
+}
 
-gulp.task('coverage', function () {
+function coverage() {
     fsExtra.removeSync('coverage/server');
     child_process.execSync('nyc' +
         ' --all' +
@@ -57,12 +64,12 @@ gulp.task('coverage', function () {
         ' -x "specs/**" -x "coverage/**" -x "doc/**" -x "bin/**" -x "index.js" -x "gulpfile.js"' +
         ' node_modules/jasmine/bin/jasmine.js' +
         ' JASMINE_CONFIG_PATH=specs/jasmine.json', {
-        stdio: [process.stdin, process.stdout, process.stderr]
-    });
-    open('coverage/lcov-report/index.html');
-});
+            stdio: [process.stdin, process.stdout, process.stderr]
+        });
+    return open('coverage/lcov-report/index.html');
+}
 
-gulp.task('cloc', function() {
+function cloc() {
     var cmdLine;
     var clocPath = path.join('node_modules', 'cloc', 'lib', 'cloc');
 
@@ -98,4 +105,4 @@ gulp.task('cloc', function() {
             });
         });
     });
-});
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ function test(done) {
 }
 
 function testWatch() {
-    gulp.watch(specFiles).on('change', function () {
+    return gulp.watch(specFiles).on('change', function () {
         // We can't simply depend on the test task because Jasmine
         // does not like being run multiple times in the same process.
         try {
@@ -55,7 +55,7 @@ function testWatch() {
     });
 }
 
-function coverage() {
+async function coverage() {
     fsExtra.removeSync('coverage/server');
     child_process.execSync('nyc' +
         ' --all' +
@@ -66,7 +66,7 @@ function coverage() {
         ' JASMINE_CONFIG_PATH=specs/jasmine.json', {
             stdio: [process.stdin, process.stdout, process.stderr]
         });
-    return open('coverage/lcov-report/index.html');
+    open('coverage/lcov-report/index.html');
 }
 
 function cloc() {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coveralls": "^3.0.2",
     "eslint": "^5.6.1",
     "eslint-config-cesium": "^6.0.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
     "jsdoc": "^3.5.5",


### PR DESCRIPTION
`gulp.task` was replaced with `module.exports` but no other changes were required.