### PR TITLE
Option for saving 'gltf.extras'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ As a convenience the PBR textures may be supplied directly to the command line.
 |`--baseColorTexture`|Path to the baseColor/diffuse texture that should override textures in the .mtl file.|No|
 |`--emissiveTexture`|Path to the emissive texture that should override textures in the .mtl file.|No|
 |`--alphaTexture`|Path to the alpha texture that should override textures in the .mtl file.|No|
-|`--extras`|An object for storing application-specific data. It will be saved to the root object for a gLTF asset.|No|
+|`--extrasPath`|Path to the json file that contains an object for storing application-specific data. It will be saved to the top-level of the glTF.|No|
 
 ## Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ As a convenience the PBR textures may be supplied directly to the command line.
 |`--baseColorTexture`|Path to the baseColor/diffuse texture that should override textures in the .mtl file.|No|
 |`--emissiveTexture`|Path to the emissive texture that should override textures in the .mtl file.|No|
 |`--alphaTexture`|Path to the alpha texture that should override textures in the .mtl file.|No|
+|`--extras`|An object for storing application-specific data. It will be saved to the root object for a gLTF asset.|No|
 
 ## Build Instructions
 

--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -122,6 +122,10 @@ const argv = yargs
             describe : 'The glTF will be saved with the KHR_materials_unlit extension.',
             type : 'boolean',
             default : defaults.unlit
+        },
+        extras : {
+            describe : 'An object for storing application-specific data. It will be saved to the root object for a gLTF asset.',
+            type : 'object'
         }
     }).parse(args);
 
@@ -167,7 +171,8 @@ const options = {
     specularGlossiness : argv.specularGlossiness,
     unlit : argv.unlit,
     overridingTextures : overridingTextures,
-    outputDirectory : outputDirectory
+    outputDirectory : outputDirectory,
+    extras: argv.extras
 };
 
 console.time('Total');

--- a/bin/obj2gltf.js
+++ b/bin/obj2gltf.js
@@ -123,9 +123,16 @@ const argv = yargs
             type : 'boolean',
             default : defaults.unlit
         },
-        extras : {
-            describe : 'An object for storing application-specific data. It will be saved to the root object for a gLTF asset.',
-            type : 'object'
+        extrasPath : {
+            describe : 'Path to the json file that contains an object for storing application-specific data. It will be saved to the top-level of the glTF.',
+            type : 'string',
+            normalize : true,
+            coerce : function (p) {
+                if (p.length === 0) {
+                    throw new Error('Input path must be a file name');
+                }
+                return path.resolve(p);
+            }
         }
     }).parse(args);
 
@@ -171,9 +178,12 @@ const options = {
     specularGlossiness : argv.specularGlossiness,
     unlit : argv.unlit,
     overridingTextures : overridingTextures,
-    outputDirectory : outputDirectory,
-    extras: argv.extras
+    outputDirectory : outputDirectory
 };
+
+if (defined(argv.extrasPath)) {
+    options.extras = JSON.parse(fsExtra.readFileSync(argv.extrasPath));
+}
 
 console.time('Total');
 

--- a/lib/createGltf.js
+++ b/lib/createGltf.js
@@ -108,6 +108,10 @@ function createGltf(objData, options) {
         gltf.extensionsRequired.push('KHR_materials_unlit');
     }
 
+    if (options.extras) {
+        gltf.extras = options.extras;
+    }
+
     return gltf;
 }
 

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -37,7 +37,7 @@ module.exports = obj2gltf;
  * @param {Logger} [options.logger] A callback function for handling logged messages. Defaults to console.log.
  * @param {Writer} [options.writer] A callback function that writes files that are saved as separate resources.
  * @param {String} [options.outputDirectory] Output directory for writing separate resources when options.writer is not defined.
- * @param {Object} [options.extras] An object for storing application-specific data. It will be saved to the root object for a gLTF asset.
+ * @param {Object} [options.extras] An object for storing application-specific data. It will be saved to the top-level of the glTF.
  * @return {Promise} A promise that resolves to the glTF JSON or glb buffer.
  */
 function obj2gltf(objPath, options) {

--- a/lib/obj2gltf.js
+++ b/lib/obj2gltf.js
@@ -37,6 +37,7 @@ module.exports = obj2gltf;
  * @param {Logger} [options.logger] A callback function for handling logged messages. Defaults to console.log.
  * @param {Writer} [options.writer] A callback function that writes files that are saved as separate resources.
  * @param {String} [options.outputDirectory] Output directory for writing separate resources when options.writer is not defined.
+ * @param {Object} [options.extras] An object for storing application-specific data. It will be saved to the root object for a gLTF asset.
  * @return {Promise} A promise that resolves to the glTF JSON or glb buffer.
  */
 function obj2gltf(objPath, options) {

--- a/specs/data/extras/dummy.json
+++ b/specs/data/extras/dummy.json
@@ -1,0 +1,16 @@
+{
+    "cities": [
+        "Bangkok",
+        "Beijing",
+        "Jarkata",
+        "Sydney",
+        "London",
+        "Tokyo",
+        "San Francisco",
+        "New York"
+    ],
+    "coordinates": {
+        "x": 35.12,
+        "y": -21.49
+    }
+}

--- a/specs/lib/obj2gltfSpec.js
+++ b/specs/lib/obj2gltfSpec.js
@@ -14,6 +14,8 @@ const outputDirectory = 'output';
 
 const textureUrl = 'specs/data/box-textured/cesium.png';
 
+const extrasPath = 'specs/data/extras/dummy.json';
+
 describe('obj2gltf', () => {
     beforeEach(() => {
         spyOn(fsExtra, 'outputFile').and.returnValue(Promise.resolve());
@@ -53,6 +55,17 @@ describe('obj2gltf', () => {
         };
         await obj2gltf(texturedObjPath, options);
         expect(fsExtra.outputFile.calls.count()).toBe(5); // Saves out .png and four .bin for positions, normals, uvs, and indices
+    });
+
+    it('converts obj to gltf with extras', async () => {
+        const extras = JSON.parse(fsExtra.readFileSync(extrasPath));
+        const options = {
+            extras : extras
+        };
+        const gltf = await obj2gltf(texturedObjPath, options);
+        expect(gltf).toBeDefined();
+        expect(gltf.images.length).toBe(1);
+        expect(gltf.extras).toBe(extras);
     });
 
     it('converts obj to glb with separate resources', async () => {


### PR DESCRIPTION
Hello,

According to the glTF 2.0 specification, `extras` is one of the properties of the root object for a glTF asset. Its purpose is for storing application-specific data. See: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-gltf

This PR adds a new command line flag `--extrasPath` for specifying the path to a JSON file that contains an object for storing application-specific data. It also adds an option `extras` for specifying the object when using obj2gltf as a library. The object will be saved to the top-level of the glTF.

Although the type of `extras` is `any` which includes primitive types, the discussion on the glTF spec for primitive extras has resolved — extras should be objects as best practice, and primitive extras may be disallowed in the future. See: https://github.com/KhronosGroup/glTF/issues/1120

Best,
