### PR TITLE
Short circuits the image combining if diffuse and alpha textures are the same

### DIFF
--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -388,6 +388,7 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     }
 
     if (diffuseTexture.path === alphaTexture.path) {
+        diffuseTexture.transparent = true;
         return diffuseTexture;
     }
 
@@ -590,7 +591,7 @@ function createSpecularGlossinessMaterial(material, options) {
         emissiveFactor = [1.0, 1.0, 1.0];
     }
 
-    if (defined(diffuseTexture)) {
+    if (defined(diffuseAlphaTexture)) {
         diffuseFactor = [1.0, 1.0, 1.0, 1.0];
     }
 
@@ -611,8 +612,8 @@ function createSpecularGlossinessMaterial(material, options) {
         transparent = alpha < 1.0;
     }
 
-    if (defined(diffuseTexture)) {
-        transparent = transparent || diffuseTexture.transparent;
+    if (defined(diffuseAlphaTexture)) {
+        transparent = transparent || diffuseAlphaTexture.transparent;
     }
 
     const doubleSided = transparent;
@@ -662,7 +663,7 @@ function createMetallicRoughnessMaterial(material, options) {
         emissiveFactor = [1.0, 1.0, 1.0];
     }
 
-    if (defined(baseColorTexture)) {
+    if (defined(diffuseAlphaTexture)) {
         baseColorFactor = [1.0, 1.0, 1.0, 1.0];
     }
 
@@ -683,8 +684,8 @@ function createMetallicRoughnessMaterial(material, options) {
         transparent = alpha < 1.0;
     }
 
-    if (defined(baseColorTexture)) {
-        transparent = transparent || baseColorTexture.transparent;
+    if (defined(diffuseAlphaTexture)) {
+        transparent = transparent || diffuseAlphaTexture.transparent;
     }
 
     const doubleSided = transparent;

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -387,6 +387,10 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
         return diffuseTexture;
     }
 
+    if (diffuseTexture.path === alphaTexture.path) {
+        return diffuseTexture;
+    }
+
     if (!defined(diffuseTexture.pixels) || !defined(alphaTexture.pixels)) {
         options.logger('Could not get decoded texture data for ' + diffuseTexture.path + ' or ' + alphaTexture.path + '. The material will be created without an alpha texture.');
         return diffuseTexture;

--- a/lib/loadMtl.js
+++ b/lib/loadMtl.js
@@ -388,7 +388,6 @@ function createDiffuseAlphaTexture(diffuseTexture, alphaTexture, options) {
     }
 
     if (diffuseTexture.path === alphaTexture.path) {
-        diffuseTexture.transparent = true;
         return diffuseTexture;
     }
 

--- a/specs/lib/loadMtlSpec.js
+++ b/specs/lib/loadMtlSpec.js
@@ -322,16 +322,20 @@ describe('loadMtl', () => {
             expect(material.doubleSided).toBe(true);
         });
 
-        it('uses diffuse texture if diffuse and alpha are the same', () => {
+        it('uses diffuse texture if diffuse and alpha are the same', async () => {
             options.metallicRoughness = true;
 
+            // The transparent property will be modified so make a copy
+            const diffuseTextureCopy = await loadTexture(diffuseTexturePath, decodeOptions);
             const material = loadMtl._createMaterial({
-                diffuseTexture : diffuseTexture,
+                diffuseTexture : diffuseTextureCopy,
                 alphaTexture : diffuseTexture
             }, options);
 
             const pbr = material.pbrMetallicRoughness;
-            expect(pbr.baseColorTexture).toBe(diffuseTexture);
+            expect(pbr.baseColorTexture).toBe(diffuseTextureCopy);
+            expect(material.alphaMode).toBe('BLEND');
+            expect(material.doubleSided).toBe(true);
         });
     });
 
@@ -425,6 +429,22 @@ describe('loadMtl', () => {
             expect(hasBlack).toBe(true);
             expect(hasWhite).toBe(true);
             expect(pbr.diffuseFactor[3]).toEqual(1);
+            expect(material.alphaMode).toBe('BLEND');
+            expect(material.doubleSided).toBe(true);
+        });
+
+        it('uses diffuse texture if diffuse and alpha are the same', async () => {
+            options.specularGlossiness = true;
+
+            // The transparent property will be modified so make a copy
+            const diffuseTextureCopy = await loadTexture(diffuseTexturePath, decodeOptions);
+            const material = loadMtl._createMaterial({
+                diffuseTexture : diffuseTextureCopy,
+                alphaTexture : diffuseTexture
+            }, options);
+
+            const pbr = material.extensions.KHR_materials_pbrSpecularGlossiness;
+            expect(pbr.diffuseTexture).toEqual(diffuseTextureCopy);
             expect(material.alphaMode).toBe('BLEND');
             expect(material.doubleSided).toBe(true);
         });

--- a/specs/lib/loadMtlSpec.js
+++ b/specs/lib/loadMtlSpec.js
@@ -321,6 +321,18 @@ describe('loadMtl', () => {
             expect(material.alphaMode).toBe('BLEND');
             expect(material.doubleSided).toBe(true);
         });
+
+        it('uses diffuse texture if diffuse and alpha are the same', () => {
+            options.metallicRoughness = true;
+
+            const material = loadMtl._createMaterial({
+                diffuseTexture : diffuseTexture,
+                alphaTexture : diffuseTexture
+            }, options);
+
+            const pbr = material.pbrMetallicRoughness;
+            expect(pbr.baseColorTexture).toBe(diffuseTexture);
+        });
     });
 
     describe('specularGlossiness', () => {


### PR DESCRIPTION
Some materials seem to have the diffuse and alpha textures set to the same file, so no need to combine them. Also added a test.